### PR TITLE
Update links to match repo transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # ipylgbst
 
-[![Github Actions Status](https://github.com/jupyterlab-contrib/ipylgbst/workflows/Build/badge.svg)](https://github.com/jupyterlab-contrib/rise/actions/workflows/build.yml) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/ipylgbst/main)
+[![Github Actions Status](https://github.com/jupyter-robotics/ipylgbst/workflows/Build/badge.svg)](https://github.com/jupyter-robotics/rise/actions/workflows/build.yml) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-robotics/ipylgbst/main)
 
 A widget library for controlling LEGO® BOOST via web-bluetooth.
 

--- a/docs/source/develop-install.rst
+++ b/docs/source/develop-install.rst
@@ -6,7 +6,7 @@ Developer install
 To install a developer version of ipylgbst, you will first need to clone
 the repository::
 
-    git clone https://github.com/jupyterlab-contrib-ipylgbst
+    git clone https://github.com/jupyter-robotics/ipylgbst
     cd ipylgbst
 
 Next, install it with a develop install using pip::

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
         "dist/*.js",
         "css/*.css"
     ],
-    "homepage": "https://github.com/jupyterlab-contrib-ipylgbst",
+    "homepage": "https://github.com/jupyter-robotics/ipylgbst",
     "bugs": {
-        "url": "https://github.com/jupyterlab-contrib-ipylgbst/issues"
+        "url": "https://github.com/jupyter-robotics/ipylgbst/issues"
     },
     "license": "BSD-3-Clause",
     "author": {
@@ -26,7 +26,7 @@
     "types": "./lib/index.d.ts",
     "repository": {
         "type": "git",
-        "url": "https://github.com/jupyterlab-contrib-ipylgbst"
+        "url": "https://github.com/jupyter-robotics/ipylgbst"
     },
     "scripts": {
         "build": "jlpm run build:lib && jlpm run build:nbextension && jlpm run build:labextension:dev",


### PR DESCRIPTION
Transferred repo from `jupyterlab-contrib` to `jupyter-robotics`. This PR updates links to point to the new homepage. Changelog left unchanged since all links are redirected.